### PR TITLE
Got rid of footer and header when users register for tickets

### DIFF
--- a/app/components/Landing.tsx
+++ b/app/components/Landing.tsx
@@ -1,7 +1,11 @@
 import RegisterButton from "./RegisterButton";
+import Header from "./Header";
+import Footer from "./Footer";
 
 export default function Landing() {
   return (
+    <>
+    <Header />
     <div className="relative grid grid-cols-6 grid-rows-12 p-12 h-[90vh] justify-around">
       {/* background image */}
       <div className="absolute inset-0 -z-1">
@@ -29,5 +33,7 @@ export default function Landing() {
         <RegisterButton classes="text-3xl" />
       </div>
     </div>
+    <Footer />
+    </>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,9 +27,7 @@ export default function RootLayout({
       <body
         className={`flex flex-col min-h-screen ${instrumentSans.className} antialiased`}
       >
-        <Header />
         {children}
-        <Footer />
       </body>
     </html>
   );


### PR DESCRIPTION
Made it so that when users click the "get tickets" button the footer and header aren't on the registration/payment pages.